### PR TITLE
Package evercrypt-ctypes.0.1

### DIFF
--- a/packages/evercrypt-ctypes/evercrypt-ctypes.0.1/opam
+++ b/packages/evercrypt-ctypes/evercrypt-ctypes.0.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: [ "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>" ]
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+license: "Apache-2.0"
+synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
+description: """
+This package contains a snapshot of the EverCrypt crypto provider and
+the HACL* library, along with automatically generated Ctypes bindings.
+For a higher-level idiomatic API see the `evercrypt` package, of
+which `evercrypt-ctypes` is a dependency.
+"""
+depends: [
+  "ocaml" { >= "4.05.0" }
+  "ocamlfind"
+  "ctypes"
+  "ctypes-foreign"
+]
+build: [
+  [make]
+]
+install: [
+  make "install-evercrypt-ctypes"
+]
+url {
+  src: "https://github.com/project-everest/hacl-star/archive/v0.2.1.tar.gz"
+  checksum: [
+    "md5=4d63939003453511c764f8dbcdad651b"
+    "sha512=d060eb17d2de73021667d04b2ee5174662694bd2a10fc0e76f2796314c322720ca0c0d93f0921a89226f655e0423cda2c5a79fad0f6ca22a18d9d81fb0e45b02"
+  ]
+}


### PR DESCRIPTION
### `evercrypt-ctypes.0.1`
Auto-generated low-level OCaml bindings for EverCrypt/HACL*
This package contains a snapshot of the EverCrypt crypto provider and
the HACL* library, along with automatically generated Ctypes bindings.
For a higher-level idiomatic API see the `evercrypt` package, of
which `evercrypt-ctypes` is a dependency.



---
* Homepage: https://hacl-star.github.io/
* Source repo: git+https://github.com/project-everest/hacl-star.git
* Bug tracker: https://github.com/project-everest/hacl-star/issues

---
:camel: Pull-request generated by opam-publish v2.0.2