### PR TITLE
Package hacl-star.0.1

### DIFF
--- a/packages/hacl-star/hacl-star.0.1/opam
+++ b/packages/hacl-star/hacl-star.0.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "OCaml API for EverCrypt/HACL*"
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "bigstring"
+  "zarith"
+  "hacl-star-raw"
+]
+build: [make "hacl-star"]
+run-test: [make "runtest" "hacl-star"]
+install: [make "hacl-star"]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/victor-dumitrescu/hacl-star/raw/master/archive/hacl-star.0.1.tar.gz"
+  checksum: [
+    "md5=2f45b61e6955c615b0e6569be7f993eb"
+    "sha512=6a1fedd12b10ad2f75774cde49733adc52180f6a11ca0ec9b8cff9d08e3b9d1b7fb776b32f8f9f82dbb5e824c57e4f526ed8375bf595b091b7d34dcc23b3d9de"
+  ]
+}


### PR DESCRIPTION
### `hacl-star.0.1`
OCaml API for EverCrypt/HACL*



---
* Homepage: https://hacl-star.github.io/
* Source repo: git+https://github.com/project-everest/hacl-star.git
* Bug tracker: https://github.com/project-everest/hacl-star/issues

---
:camel: Pull-request generated by opam-publish v2.0.2