### PR TITLE
2 packages from victor-dumitrescu/hacl-star at 0.1

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
+description: """
+This package contains a snapshot of the EverCrypt crypto provider and
+the HACL* library, along with automatically generated Ctypes bindings.
+For a higher-level idiomatic API see the `evercrypt` package, of
+which `evercrypt-ctypes` is a dependency."""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind"
+  "ctypes"
+  "ctypes-foreign"
+]
+build: [make "raw"]
+install: [make "raw"]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/victor-dumitrescu/hacl-star/raw/master/archive/hacl-star.0.1.tar.gz"
+  checksum: [
+    "md5=2f45b61e6955c615b0e6569be7f993eb"
+    "sha512=6a1fedd12b10ad2f75774cde49733adc52180f6a11ca0ec9b8cff9d08e3b9d1b7fb776b32f8f9f82dbb5e824c57e4f526ed8375bf595b091b7d34dcc23b3d9de"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`hacl-star.0.1`: OCaml API for EverCrypt/HACL*
-`hacl-star-raw.0.1`: Auto-generated low-level OCaml bindings for EverCrypt/HACL*



---
* Homepage: https://hacl-star.github.io/
* Source repo: git+https://github.com/project-everest/hacl-star.git
* Bug tracker: https://github.com/project-everest/hacl-star/issues

---
:camel: Pull-request generated by opam-publish v2.0.2