### PR TITLE
Package hacl-star-raw.0.1

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
+description: """
+This package contains a snapshot of the EverCrypt crypto provider and
+the HACL* library, along with automatically generated Ctypes bindings.
+For a higher-level idiomatic API see the `hacl-star` package, of
+which `hacl-star-raw` is a dependency."""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind"
+  "ctypes"
+  "ctypes-foreign"
+]
+build: make
+install: [make "install-evercrypt-ctypes"]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/victor-dumitrescu/hacl-star/raw/master/archive/hacl-star-raw.0.1.tar.gz"
+  checksum: [
+    "md5=148212d4eea3275c1b4402869b6716aa"
+    "sha512=1f7b1263d90e3137997516d0297da3c78a62956135dbd6954bb726be9466f6f9c78eba159ab1febc94ea94a456b76d0634ebb150e8202a6931e15f0af60e3719"
+  ]
+}


### PR DESCRIPTION
### `hacl-star-raw.0.1`
Auto-generated low-level OCaml bindings for EverCrypt/HACL*
This package contains a snapshot of the EverCrypt crypto provider and
the HACL* library, along with automatically generated Ctypes bindings.
For a higher-level idiomatic API see the `hacl-star` package, of
which `hacl-star-raw` is a dependency.



---
* Homepage: https://hacl-star.github.io/
* Source repo: git+https://github.com/project-everest/hacl-star.git
* Bug tracker: https://github.com/project-everest/hacl-star/issues

---
:camel: Pull-request generated by opam-publish v2.0.2