### PR TITLE
2 packages from victor-dumitrescu/hacl-star at 0.1

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.1/opam
@@ -16,14 +16,14 @@ depends: [
   "ctypes"
   "ctypes-foreign"
 ]
-build: make
-install: [make "install-evercrypt-ctypes"]
+build: [make "-C" "raw"]
+install: [make "-C" "raw" "install-evercrypt-ctypes"]
 dev-repo: "git+https://github.com/project-everest/hacl-star.git"
 url {
   src:
-    "https://github.com/victor-dumitrescu/hacl-star/raw/master/archive/hacl-star-raw.0.1.tar.gz"
+    "https://github.com/victor-dumitrescu/hacl-star/raw/master/archive/hacl-star.0.1.tar.gz"
   checksum: [
-    "md5=148212d4eea3275c1b4402869b6716aa"
-    "sha512=1f7b1263d90e3137997516d0297da3c78a62956135dbd6954bb726be9466f6f9c78eba159ab1febc94ea94a456b76d0634ebb150e8202a6931e15f0af60e3719"
+    "md5=91e3ed8c7f3ac960624b6a511d2eda85"
+    "sha512=0f174fdf54566a44e0bef973ee21805b4402cc844e8dda35a5a2fce3ac0541e4c5fa6b123aaa201b938e2127ba17b93cc8b01754d47b82cf981be9e7fef76cd7"
   ]
 }

--- a/packages/hacl-star/hacl-star.0.1/opam
+++ b/packages/hacl-star/hacl-star.0.1/opam
@@ -18,7 +18,7 @@ url {
   src:
     "https://github.com/victor-dumitrescu/hacl-star/raw/master/archive/hacl-star.0.1.tar.gz"
   checksum: [
-    "md5=0895623a93251af07f58471d8848b103"
-    "sha512=3b7a677ebce79b2dbf7c4d3911535c5f9920d166ceb8ac442e955561cb35096161e36625d24dffaa5fa82a1f850858c579c44419f0e8f4fe5826c68206cf87d1"
+    "md5=91e3ed8c7f3ac960624b6a511d2eda85"
+    "sha512=0f174fdf54566a44e0bef973ee21805b4402cc844e8dda35a5a2fce3ac0541e4c5fa6b123aaa201b938e2127ba17b93cc8b01754d47b82cf981be9e7fef76cd7"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
-`hacl-star.0.1`: OCaml API for EverCrypt/HACL*
-`hacl-star-raw.0.1`: Auto-generated low-level OCaml bindings for EverCrypt/HACL*



---
* Homepage: https://hacl-star.github.io/
* Source repo: git+https://github.com/project-everest/hacl-star.git
* Bug tracker: https://github.com/project-everest/hacl-star/issues

---
:camel: Pull-request generated by opam-publish v2.0.2