### PR TITLE
2 packages from project-everest/hacl-star at 0.1

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.1/opam
@@ -17,13 +17,13 @@ depends: [
   "ctypes-foreign"
 ]
 build: [make "-C" "raw"]
-install: [make "-C" "raw" "install-evercrypt-ctypes"]
+install: [make "-C" "raw" "install-hacl-star-raw"]
 dev-repo: "git+https://github.com/project-everest/hacl-star.git"
 url {
   src:
-    "https://github.com/victor-dumitrescu/hacl-star/raw/master/archive/hacl-star.0.1.tar.gz"
+    "https://github.com/project-everest/hacl-star/raw/vdum_ctypes_evercrypt/bindings/ocaml/archive/hacl-star.0.1.tar.gz"
   checksum: [
-    "md5=91e3ed8c7f3ac960624b6a511d2eda85"
-    "sha512=0f174fdf54566a44e0bef973ee21805b4402cc844e8dda35a5a2fce3ac0541e4c5fa6b123aaa201b938e2127ba17b93cc8b01754d47b82cf981be9e7fef76cd7"
+    "md5=7b217d260adba48399591dd69d418011"
+    "sha512=5a4a8a7c088ecc2af93bc94bef226ca3d80f79221f4cfe5499212e1d59836b637a64991f2ba4bb696a1e9eef50dc9b60e1692ce1e499909b2ca79cccc6207243"
   ]
 }

--- a/packages/hacl-star/hacl-star.0.1/opam
+++ b/packages/hacl-star/hacl-star.0.1/opam
@@ -16,9 +16,9 @@ run-test: ["dune" "runtest"]
 dev-repo: "git+https://github.com/project-everest/hacl-star.git"
 url {
   src:
-    "https://github.com/victor-dumitrescu/hacl-star/raw/master/archive/hacl-star.0.1.tar.gz"
+    "https://github.com/project-everest/hacl-star/raw/vdum_ctypes_evercrypt/bindings/ocaml/archive/hacl-star.0.1.tar.gz"
   checksum: [
-    "md5=91e3ed8c7f3ac960624b6a511d2eda85"
-    "sha512=0f174fdf54566a44e0bef973ee21805b4402cc844e8dda35a5a2fce3ac0541e4c5fa6b123aaa201b938e2127ba17b93cc8b01754d47b82cf981be9e7fef76cd7"
+    "md5=7b217d260adba48399591dd69d418011"
+    "sha512=5a4a8a7c088ecc2af93bc94bef226ca3d80f79221f4cfe5499212e1d59836b637a64991f2ba4bb696a1e9eef50dc9b60e1692ce1e499909b2ca79cccc6207243"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
-`hacl-star.0.1`: OCaml API for EverCrypt/HACL*
-`hacl-star-raw.0.1`: Auto-generated low-level OCaml bindings for EverCrypt/HACL*



---
* Homepage: https://hacl-star.github.io/
* Source repo: git+https://github.com/project-everest/hacl-star.git
* Bug tracker: https://github.com/project-everest/hacl-star/issues

---
:camel: Pull-request generated by opam-publish v2.0.2