### PR TITLE
2 packages from project-everest/hacl-star at 0.1

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.1/opam
@@ -21,9 +21,9 @@ install: [make "-C" "raw" "install-hacl-star-raw"]
 dev-repo: "git+https://github.com/project-everest/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/raw/vdum_ctypes_evercrypt/bindings/ocaml/archive/hacl-star.0.1.tar.gz"
+    "https://github.com/project-everest/hacl-star/raw/master/bindings/ocaml/archive/hacl-star.0.1.tar.gz"
   checksum: [
-    "md5=7b217d260adba48399591dd69d418011"
-    "sha512=5a4a8a7c088ecc2af93bc94bef226ca3d80f79221f4cfe5499212e1d59836b637a64991f2ba4bb696a1e9eef50dc9b60e1692ce1e499909b2ca79cccc6207243"
+    "md5=a6a18ae1e0f039ef070aa27de9852b25"
+    "sha512=c1ad27155a5f5aae521464c2e48d847c4dabb4ae17524fc8df63cf9dd0f81edbb0de16cc1ea92a678e90fbb005279f99ec8cc1e4159ca41138310748c41bee46"
   ]
 }

--- a/packages/hacl-star/hacl-star.0.1/opam
+++ b/packages/hacl-star/hacl-star.0.1/opam
@@ -8,7 +8,6 @@ bug-reports: "https://github.com/project-everest/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "hacl-star-raw"
-  "bigstring"
   "zarith"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
@@ -16,9 +15,9 @@ run-test: ["dune" "runtest"]
 dev-repo: "git+https://github.com/project-everest/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/raw/vdum_ctypes_evercrypt/bindings/ocaml/archive/hacl-star.0.1.tar.gz"
+    "https://github.com/project-everest/hacl-star/raw/master/bindings/ocaml/archive/hacl-star.0.1.tar.gz"
   checksum: [
-    "md5=7b217d260adba48399591dd69d418011"
-    "sha512=5a4a8a7c088ecc2af93bc94bef226ca3d80f79221f4cfe5499212e1d59836b637a64991f2ba4bb696a1e9eef50dc9b60e1692ce1e499909b2ca79cccc6207243"
+    "md5=a6a18ae1e0f039ef070aa27de9852b25"
+    "sha512=c1ad27155a5f5aae521464c2e48d847c4dabb4ae17524fc8df63cf9dd0f81edbb0de16cc1ea92a678e90fbb005279f99ec8cc1e4159ca41138310748c41bee46"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
-`hacl-star.0.1`: OCaml API for EverCrypt/HACL*
-`hacl-star-raw.0.1`: Auto-generated low-level OCaml bindings for EverCrypt/HACL*



---
* Homepage: https://hacl-star.github.io/
* Source repo: git+https://github.com/project-everest/hacl-star.git
* Bug tracker: https://github.com/project-everest/hacl-star/issues

---
:camel: Pull-request generated by opam-publish v2.0.2