### PR TITLE
2 packages from project-everest/hacl-star at 0.1

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.1/opam
@@ -17,16 +17,16 @@ depends: [
   "ctypes-foreign"
 ]
 build: [
-  ["./raw/configure"]
+  ["sh" "-exc" "cd raw && ./configure"]
   [make "-C" "raw"]
 ]
 install: [make "-C" "raw" "install-hacl-star-raw"]
 dev-repo: "git+https://github.com/project-everest/hacl-star.git"
 url {
   src:
-    "https://github.com/victor-dumitrescu/hacl-star/releases/download/ocaml-v0.1/hacl-star.0.1.tar.gz"
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.1/hacl-star.0.1.tar.gz"
   checksum: [
-    "md5=ba822929cbb5f0ab83d000830ac180f9"
-    "sha512=34b2fb42fda284e4235e29b45343b643e1bf41dcea498d64ce6ed62317e99587bbc7b384425f656c736983c6c86523d9fae57e79c15417a7fca82a64ad33b3f8"
+    "md5=b1c111f4d3e883f427ce7a86bceb985e"
+    "sha512=774c7dca9b44c50307df73d8f850fcf24dc1c5da29b09266316ff19bfa52a7537b39ea799e22066b4fc8664915e1f04c2c51e88301daa122af165c183bf0135d"
   ]
 }

--- a/packages/hacl-star/hacl-star.0.1/opam
+++ b/packages/hacl-star/hacl-star.0.1/opam
@@ -16,9 +16,9 @@ run-test: ["dune" "runtest" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/project-everest/hacl-star.git"
 url {
   src:
-    "https://github.com/victor-dumitrescu/hacl-star/releases/download/ocaml-v0.1/hacl-star.0.1.tar.gz"
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.1/hacl-star.0.1.tar.gz"
   checksum: [
-    "md5=ba822929cbb5f0ab83d000830ac180f9"
-    "sha512=34b2fb42fda284e4235e29b45343b643e1bf41dcea498d64ce6ed62317e99587bbc7b384425f656c736983c6c86523d9fae57e79c15417a7fca82a64ad33b3f8"
+    "md5=b1c111f4d3e883f427ce7a86bceb985e"
+    "sha512=774c7dca9b44c50307df73d8f850fcf24dc1c5da29b09266316ff19bfa52a7537b39ea799e22066b4fc8664915e1f04c2c51e88301daa122af165c183bf0135d"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
-`hacl-star.0.1`: OCaml API for EverCrypt/HACL*
-`hacl-star-raw.0.1`: Auto-generated low-level OCaml bindings for EverCrypt/HACL*



---
* Homepage: https://hacl-star.github.io/
* Source repo: git+https://github.com/project-everest/hacl-star.git
* Bug tracker: https://github.com/project-everest/hacl-star/issues

---
:camel: Pull-request generated by opam-publish v2.0.2